### PR TITLE
Implement sniper changes in bps

### DIFF
--- a/hook/lua/system/Blueprints.lua
+++ b/hook/lua/system/Blueprints.lua
@@ -81,6 +81,6 @@ do  -- Hook Start
                 end
             end
         end
-        table.remove(all_bps.Projectile['/mods/4dc/projectiles/sniper_piercing/sniper_piercing_proj.bp'].Categories, 2)
+        --table.remove(all_bps.Projectile['/mods/4dc/projectiles/sniper_piercing/sniper_piercing_proj.bp'].Categories, 2)
     end
 end

--- a/projectiles/Sniper_NonPiercing/Sniper_NonPiercing_proj.bp
+++ b/projectiles/Sniper_NonPiercing/Sniper_NonPiercing_proj.bp
@@ -1,0 +1,38 @@
+ProjectileBlueprint {
+    Audio = {
+        Impact = Sound {
+            Bank = 'Impacts',
+            Cue = 'UEF_Expl_Med_Impact',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactTerrain = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Land_Gen_UEF',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactWater = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Water_Splash_UEF',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+    },
+
+    Categories = {
+        'PROJECTILE',        -- required for "Shield Piercing"
+    },
+
+    Display = {
+        ImpactEffects = {Scale = 0.4,Type = 'Medium01'},
+        StrategicIconSize = 2,
+    },
+
+    Physics = {
+        DestroyOnWater = true,
+        InitialSpeed = 14.6,
+        InitialSpeedRange = 3,
+        InitialSpeedReduceDistance = 30,
+        LeadTarget = false,
+        TurnRate = 360,
+        VelocityAlign = true,
+    },
+}

--- a/projectiles/Sniper_NonPiercing/Sniper_NonPiercing_script.lua
+++ b/projectiles/Sniper_NonPiercing/Sniper_NonPiercing_script.lua
@@ -1,0 +1,5 @@
+local Sniper_NonPiercingProjectile = import('/lua/aeonprojectiles.lua').AHighIntensityLaserProjectile  
+
+Sniper_NonPiercing = Class(Sniper_NonPiercingProjectile) {}
+
+TypeClass = Sniper_NonPiercing

--- a/units/4DC/UAL0204/UAL0204_unit.bp
+++ b/units/4DC/UAL0204/UAL0204_unit.bp
@@ -54,7 +54,7 @@ UnitBlueprint {
 
             MuzzleVelocity = 60,
 
-            ProjectileId = "/mods/loud-community-edition/projectiles/sniper_nonpiercing/sniper_nonpiercing_proj.bp",
+            ProjectileId = "/mods/LOUD-Community-Edition/projectiles/Sniper_NonPiercing/Sniper_NonPiercing_proj.bp",
             ProjectileLifetime = 1,
 
             RackRecoilDistance = -4.0,

--- a/units/4DC/UAL0204/UAL0204_unit.bp
+++ b/units/4DC/UAL0204/UAL0204_unit.bp
@@ -54,7 +54,7 @@ UnitBlueprint {
 
             MuzzleVelocity = 60,
 
-            ProjectileId = "/mods/4DC/projectiles/Sniper_Piercing/Sniper_Piercing_proj.bp",
+            ProjectileId = "/mods/loud-community-edition/projectiles/sniper_nonpiercing/sniper_nonpiercing_proj.bp",
             ProjectileLifetime = 1,
 
             RackRecoilDistance = -4.0,


### PR DESCRIPTION
Original implementation required mutating
the sniper projectile's BP at runtime in
ModBlueprints.  This way creates a new
projectile that derives from the original,
but disables shield piercing.  We then
use bp merge to use the new projectile.

I think this approach is preferable because
it maximizes the changes in a declarative format.

Note: if/when we use blueprint merges, the engine
will ignore any unit scripts.  I have no idea why.