### PR TITLE
Migrated SpawnWaveThread to a no-op.

### DIFF
--- a/hook/lua/loudutilities.lua
+++ b/hook/lua/loudutilities.lua
@@ -1,0 +1,5 @@
+--Destructively hook the spawnwave thread to turn it into a noop.
+function SpawnWaveThread( aiBrain )
+	LOG("*AI DEBUG "..aiBrain.Nickname.." Spawnwave disabled")
+	aiBrain.WaveThread = nil
+end


### PR DESCRIPTION
Addresses #22

Destructively hooks the function that would invoke SpawnWave behavior and just logs that it's disabled.

We now should see 

INFO: *AI DEBUG Stash-Ushithow (AI: LOUD) Spawnwave disabled

in the game log for all AI regardless of multiplier.